### PR TITLE
Whinlatter

### DIFF
--- a/recipes-bsp/fwupd/fwupd-efi_1.2.bb
+++ b/recipes-bsp/fwupd/fwupd-efi_1.2.bb
@@ -7,7 +7,8 @@ DEPENDS = "gnu-efi"
 
 SRC_URI = "\
     git://github.com/fwupd/fwupd-efi;protocol=https;branch=main \
-    file://cc.patch"
+    file://cc.patch \
+"
 SRCREV = "8de5918507dcc797e612aac688d6b60b90053f54"
 
 COMPATIBLE_HOST = "(x86_64.*|i.86.*|aarch64.*|arm.*)-linux"
@@ -19,8 +20,7 @@ SBAT_DISTRO_ID ?= "${DISTRO}"
 SBAT_DISTRO_SUMMARY ?= "${DISTRO_NAME}"
 SBAT_DISTRO_URL ?= ""
 
-EXTRA_OEMESON += "\
-    -Defi-cc=${@meson_array('CC', d)}\
+EXTRA_OEMESON += " \
     -Defi-ld='${HOST_PREFIX}ld' \
     -Defi-includedir=${STAGING_INCDIR}/efi \
     -Defi-libdir=${STAGING_LIBDIR} \
@@ -28,7 +28,7 @@ EXTRA_OEMESON += "\
     -Defi_sbat_distro_summary='${SBAT_DISTRO_SUMMARY}' \
     -Defi_sbat_distro_url='${SBAT_DISTRO_URL}' \
     -Defi_sbat_distro_pkgname='${PN}' \
-    -Defi_sbat_distro_version='${PV}'\
+    -Defi_sbat_distro_version='${PV}' \
 "
 
 # The compile assumes GCC at present

--- a/recipes-bsp/txe-secure-boot/files/a5df001.diff
+++ b/recipes-bsp/txe-secure-boot/files/a5df001.diff
@@ -18,6 +18,7 @@ it is something that they should worry about.
 
 This commit tries to explain what actually happens here.
 
+Upstream-Status: Pending
 Change-Id: Iaa2678f5ae7c243811484c0567ced97ae0b3fc0a
 Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>
 ---

--- a/recipes-bsp/txe-secure-boot/smmstoretool_git.bb
+++ b/recipes-bsp/txe-secure-boot/smmstoretool_git.bb
@@ -2,15 +2,15 @@ SUMMARY = "Offline SMMSTORE variable modification tool"
 HOMEPAGE = "https://github.com/coreboot/coreboot"
 
 LICENSE = "GPL-2.0-or-later"
-LIC_FILES_CHKSUM = "\
-    file://${UNPACKDIR}/${BP}/LICENSES/GPL-2.0-or-later.txt;md5=261bea1168c0bdfa73232ee90df11eb6\
+LIC_FILES_CHKSUM = " \
+    file://${UNPACKDIR}/${BP}/LICENSES/GPL-2.0-or-later.txt;md5=261bea1168c0bdfa73232ee90df11eb6 \
 "
 
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = " \
-    git://github.com/coreboot/coreboot.git;branch=main;protocol=https\
-    file://a5df001.diff;patchdir=${UNPACKDIR}/${BP}\
+    git://github.com/coreboot/coreboot.git;branch=main;protocol=https \
+    file://a5df001.diff;patchdir=${UNPACKDIR}/${BB_GIT_DEFAULT_DESTSUFFIX} \
 "
 
 SRCREV = "602653abed391ae1b1445ad86d0f05b8b5b678cb"
@@ -20,15 +20,15 @@ inherit pkgconfig
 S = "${UNPACKDIR}/${BP}/util/smmstoretool"
 
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
-EXTRA_OEMAKE = ' \
-               DESTDIR="${D}" \
-               PREFIX="${prefix}" \
-               '
+EXTRA_OEMAKE = " \
+    DESTDIR="${D}" \
+    PREFIX="${prefix}" \
+"
 
 do_install() {
     oe_runmake install
 }
 
-FILES:${PN} += "\
-    ${bindir}/smmstoretool\
+FILES:${PN} += " \
+    ${bindir}/smmstoretool \
 "

--- a/recipes-support/dasharo-ectool/dasharo-ectool_0.3.8.bb
+++ b/recipes-support/dasharo-ectool/dasharo-ectool_0.3.8.bb
@@ -64,5 +64,3 @@ SRC_URI[winapi-i686-pc-windows-gnu-0.4.0.sha256sum] = "ac3b87c63620426dd9b991e5c
 SRC_URI[winapi-util-0.1.5.sha256sum] = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 SRC_URI[winapi-x86_64-pc-windows-gnu-0.4.0.sha256sum] = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 SRC_URI[winapi-0.3.9.sha256sum] = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-
-S = "${WORKDIR}/git"

--- a/recipes-tests/converged-security-suite/converged-security-suite_2.8.2.bb
+++ b/recipes-tests/converged-security-suite/converged-security-suite_2.8.2.bb
@@ -4,20 +4,15 @@ SECTION = "devel"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9"
 
-SRC_URI = "https://github.com/9elements/${BPN}/releases/download/v${PV}/artifacts-amd64.zip"
-SRC_URI[sha256sum] = "58362a5976e68c31e20ecd34338683826c920bb2f34c717dd693aecbb1f7db3d"
+GO_IMPORT = "github.com/9elements/${BPN}"
+GO_EXTRA_LDFLAGS:append = " -X main.gitcommit=${SRCREV} -X main.gittag=${PV}"
 
-S = "${UNPACKDIR}"
+inherit go-mod
 
-do_install() {
-    install -d ${D}${bindir}
-    install -m 0755 ${S}/amd-suite ${D}${bindir}
-    install -m 0755 ${S}/bg-prov ${D}${bindir}
-    install -m 0755 ${S}/bg-suite ${D}${bindir}
-    install -m 0755 ${S}/pcr0tool ${D}${bindir}
-    install -m 0755 ${S}/txt-prov ${D}${bindir}
-    install -m 0755 ${S}/txt-suite ${D}${bindir}
-}
+SRC_URI = " \
+    git://${GO_IMPORT}.git;protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX} \
+"
+SRCREV = "ba64392f925cee348bee70173b1286710e255fe2"
 
 PACKAGES =+ "${PN}-amd ${PN}-bg ${PN}-txt ${PN}-tools"
 


### PR DESCRIPTION
@macpijan 
* Finished updating layer to Whinlatter.
    * `fwupd-efi` - was failing to build due to meson errors (complained about unknown arguments passed in `efi-cc`)
    * `smmstoretool` - patch was missing `Upstream-Status`
    * `smmstoretool` - migration notes say to use `BB_GIT_DEFAULT_DESTSUFFIX` in `SRC_URI` not `BP`
    * `dasharo-ectool` - had unsupported `S = ${WORKSPACE}/git`
    * updated [`meta-coreboot`](https://github.com/zarhus/meta-coreboot/pull/9) to Whinlatter (dependency of `dcu`)
* updated `converged-security-suite` to 2.8.2 (built from source) with patch that should fix https://github.com/9elements/converged-security-suite/issues/406 (Whinlatter required to build it, older versions have too old `go`)

Tested by adding all recipes in `meta-trenchboot` and verifying some of them by printing `--help`.