### PR TITLE
update layer to wrynose

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_PRIORITY_dasharo = "80"
 
 LAYERVERSION_dasharo = "1"
 
-LAYERSERIES_COMPAT_dasharo = "whinlatter master"
+LAYERSERIES_COMPAT_dasharo = "whinlatter wrynose master"
 
 # See this comment:
 # https://github.com/Dasharo/meta-dasharo/pull/7#issuecomment-3052659291


### PR DESCRIPTION
No changes needed except LAYERSERIES_COMPAT_dasharo:

```
root@qemux86-64:~# dcu --version
0.2.1

root@qemux86-64:~# dasharo_ectool --help
dasharo_ectool

USAGE:
    dasharo_ectool [OPTIONS] <SUBCOMMAND>

OPTIONS:
        --access <access>    [default: lpc-linux] [possible values: lpc-linux, lpc-sim, hid]
    -h, --help               Print help information

SUBCOMMANDS:
    console
    fan
    flash
    flash_backup
    help            Print this message or the help of the given subcommand(s)
    info
    keymap
    led_color
    led_mode
    led_save
    led_value
    matrix
    print
    security
    set_no_input
```